### PR TITLE
Feature/normalize errors

### DIFF
--- a/cucumber/features/channel_features/channel_create.feature
+++ b/cucumber/features/channel_features/channel_create.feature
@@ -20,5 +20,5 @@ Feature: A requester asks for the creation of a Channel object
     | identity_id              | endpoint      | request_contents                 | status |
     | 01f0000000000000003f0001 | /api/channel  | channel/valid_channel_name_one   | 201    |
     | 01f0000000000000003f0002 | /api/channel  | channel/valid_channel_name_two   | 201    |
-    | 01f0000000000000003f0003 | /api/channel  | channel/duplicated_channel_name  | 409    |
+    | 01f0000000000000003f0003 | /api/channel  | channel/duplicated_channel_name  | 500    |
     | 01f0000000000000003f0001 | /api/channel  | channel/empty_channel_object     | 400    |

--- a/cucumber/features/channel_features/channel_delete_data.feature
+++ b/cucumber/features/channel_features/channel_delete_data.feature
@@ -10,7 +10,7 @@ Feature: A requester attempts to delete some Channel object's data
     | 01f0000000000000003f0001 | /api/channel/:channelId  | 01f0000000000000006f0001 | 204    |
     | 01f0000000000000003f0002 | /api/channel/:channelId  | 01f0000000000000006f0002 | 204    |
     | 01f0000000000000003f0002 | /api/channel/:channelId  | 01f0000000000000006fasdf | 400    |
-    | 01f0000000000000003f0002 | /api/channel/:channelId  | 01f0000000000000006f0004 | 400    |
+    | 01f0000000000000003f0002 | /api/channel/:channelId  | 01f0000000000000006f0004 | 500    |
     | 01f0000000000000003f0004 | /api/channel/:channelId  | 01f0000000000000006f0001 | 204    |
 
 
@@ -24,9 +24,9 @@ Feature: A requester attempts to delete some Channel object's data
     | 01f0000000000000003f0003 | /api/channel/:channelId/identities/:identityId  | 01f0000000000000003f0002 | 01f0000000000000006f0002 | 204    |
     | 01f0000000000000003f0002 | /api/channel/:channelId/identities/:identityId  | 01f0000000000000003f0001 | 01f0000000000000006f0001 | 204    |
     | 01f0000000000000003f0001 | /api/channel/:channelId/identities/:identityId  | 01f0000000000000003f0003 | 01f0000000000000006f0001 | 204    |
-    | 01f0000000000000003f0001 | /api/channel/:channelId/identities/:identityId  | 01f0000000000000003f0002 | 01f0000000000000006f0001 | 409    |
+    | 01f0000000000000003f0001 | /api/channel/:channelId/identities/:identityId  | 01f0000000000000003f0002 | 01f0000000000000006f0001 | 500    |
     | 01f0000000000000003f0001 | /api/channel/:channelId/identities/:identityId  | 01f0000000000000003f0001 | 01f0000000000000006fasdf | 400    |
-    | 01f0000000000000003f0001 | /api/channel/:channelId/identities/:identityId  | 01f0000000000000003fasdf | 01f0000000000000006f0002 | 400    |
-    | 01f0000000000000003f0002 | /api/channel/:channelId/identities/:identityId  | 01f0000000000000003f0001 | 01f0000000000000006f0004 | 400    |
-    | 01f0000000000000003f0002 | /api/channel/:channelId/identities/:identityId  | 01f0000000000000003f0004 | 01f0000000000000006f0001 | 400    |
-    | 01f0000000000000003f0001 | /api/channel/:channelId/identities/:identityId  | 01f0000000000000003f0002 | 01f0000000000000006f0001 | 409    |
+    | 01f0000000000000003f0001 | /api/channel/:channelId/identities/:identityId  | 01f0000000000000003fasdf | 01f0000000000000006f0002 | 500    |
+    | 01f0000000000000003f0002 | /api/channel/:channelId/identities/:identityId  | 01f0000000000000003f0001 | 01f0000000000000006f0004 | 500    |
+    | 01f0000000000000003f0002 | /api/channel/:channelId/identities/:identityId  | 01f0000000000000003f0004 | 01f0000000000000006f0001 | 500    |
+    | 01f0000000000000003f0001 | /api/channel/:channelId/identities/:identityId  | 01f0000000000000003f0002 | 01f0000000000000006f0001 | 500    |

--- a/cucumber/features/channel_features/channel_edit_data.feature
+++ b/cucumber/features/channel_features/channel_edit_data.feature
@@ -9,7 +9,7 @@ Examples:
   | identity_id              | endpoint                | channel_id                | status | content                        |
   | 01f0000000000000003f0001 | /api/channel/:channelId | 01f0000000000000006f0001  |  204   | channel/valid_channel_name_one |
   | 01f0000000000000003f0002 | /api/channel/:channelId | 01f0000000000000006f0003  |  204   | channel/valid_channel_name_two |
-  | 01f0000000000000003f0002 | /api/channel/:channelId | 01f0000000000000006f0004  |  400   | channel/valid_channel_name_two |
+  | 01f0000000000000003f0002 | /api/channel/:channelId | 01f0000000000000006f0004  |  500   | channel/valid_channel_name_two |
 
   Scenario Outline: check the update attempt of a Channel object based on the request body contents
     Given an authenticated identity in the app with <identity_id>

--- a/cucumber/features/channel_features/channel_get_data.feature
+++ b/cucumber/features/channel_features/channel_get_data.feature
@@ -36,7 +36,7 @@ Feature: A requester attempts to retrieve the data for a Channel object
     | 01f0000000000000003f0001 | /api/channel/:channelId/identities  | 01f0000000000000006f0001 |  200   |
     | 01f0000000000000003f0002 | /api/channel/:channelId/identities  | 01f0000000000000006f0002 |  200   |
     | 01f0000000000000003f0003 | /api/channel/:channelId/identities  | 01f0000000000000006f0003 |  200   |
-    | 01f0000000000000003f0003 | /api/channel/:channelId/identities  | 01f0000000000000006f0005 |  400   |
+    | 01f0000000000000003f0003 | /api/channel/:channelId/identities  | 01f0000000000000006f0005 |  500   |
 
 
   Scenario Outline: check the channel data associated to some other identity object

--- a/cucumber/features/channel_features/channel_get_data.feature
+++ b/cucumber/features/channel_features/channel_get_data.feature
@@ -10,6 +10,7 @@ Feature: A requester attempts to retrieve the data for a Channel object
     | 01f0000000000000003f0001 | /api/channel  |  200   |
     | 01f0000000000000003f0002 | /api/channel  |  200   |
     | 01f0000000000000003f0003 | /api/channel  |  200   |
+    |                          | /api/channel  |  401   |
 
 
   Scenario Outline: check the channel data associated to the requester identity object

--- a/cucumber/features/identity_features/identity_create.feature
+++ b/cucumber/features/identity_features/identity_create.feature
@@ -19,7 +19,7 @@ Feature: A requester asks for the creation of an identity object
     | endpoint      | request_contents               | status |
     | /api/identity | identity/valid_identity_sms    | 201    |
     | /api/identity | identity/valid_identity_apn    | 201    |
-    | /api/identity | identity/duplicated_identity   | 409    |
+    | /api/identity | identity/duplicated_identity   | 500    |
 
   Scenario Outline: check the number of channels of a new identity object based on the request body contents
     When someone makes a POST to <endpoint> with content <request_contents>

--- a/lib/middleware/check_email.js
+++ b/lib/middleware/check_email.js
@@ -1,5 +1,4 @@
 var _ = require('lodash');
-var log = require('../util/logger');
 var helper = require('../util/helper');
 var errors = require('../util/errors');
 
@@ -11,12 +10,10 @@ module.exports = function() {
     emailObj.subject = emailObj.subject || 'New echo';
 
     if (_.isEmpty(emailObj.from || !_.isString(emailObj.from) || !helper.isEmail(emailObj.from))) {
-      log.error('Missing \'from\' property in parameters', emailObj);
       return next(new errors.BadRequestError('Missing \'from\' property in parameters'));
     }
 
     if (_.isEmpty(emailObj.message) || !_.isString(emailObj.message)) {
-      log.error('Missing \'message\' String property in request body \'content\' object', emailObj);
       return next(new errors.BadRequestError('Missing \'message\' String property in request body \'content\' object'));
     }
 

--- a/lib/middleware/check_push_notification.js
+++ b/lib/middleware/check_push_notification.js
@@ -1,5 +1,4 @@
 var _ = require('lodash');
-var log = require('../util/logger');
 
 var errors = require('../util/errors');
 
@@ -12,7 +11,6 @@ module.exports = function() {
     var isValidGCM = (!_.isEmpty(notificationObj.gcm) && _.isObject(notificationObj.gcm));
 
     if (!isValidAPN && !isValidGCM) {
-      log.error('The request body must contain and \'apn\' OR a \'gcm\' non-empty object', notificationObj);
       return next(new errors.BadRequestError('The request body must contain and \'apn\' OR a \'gcm\' non-empty object'));
     }
 

--- a/lib/middleware/check_sms.js
+++ b/lib/middleware/check_sms.js
@@ -1,6 +1,5 @@
 var _ = require('lodash');
 var errors = require('../util/errors');
-var log = require('../util/logger');
 var helper = require('../util/helper');
 var config = require('config');
 
@@ -12,17 +11,14 @@ module.exports = function() {
     var smsObj = req.body.content;
 
     if (_.isEmpty(smsObj.from) || !_.isString(smsObj.from) || !helper.isPhoneNumber(smsObj.from)) {
-      log.error('Missing \'from\' property in parameters', smsObj);
       return next(new errors.BadRequestError('Missing \'from\' property in parameters'));
     }
 
     if (_.isEmpty(smsObj.message) || !_.isString(smsObj.message)) {
-      log.error('Missing \'message\' String property in request body \'content\' object', smsObj);
       return next(new errors.BadRequestError('Missing \'message\' String property in request body \'content\' object'));
     }
 
     if (smsObj.message.length > MAX_TWILIO_SMS_LENGTH) {
-      log.error('Message cannot be longer than ' + MAX_TWILIO_SMS_LENGTH + ' characters', smsObj);
       return next(new errors.BadRequestError('Message cannot be longer than ' + MAX_TWILIO_SMS_LENGTH + ' characters'));
     }
 

--- a/lib/middleware/validate_identity.js
+++ b/lib/middleware/validate_identity.js
@@ -7,6 +7,8 @@ module.exports = function() {
 
   return function(req, res, next) {
 
+    var err;
+
     if (req.isPublic) {
       return next();
     }
@@ -15,15 +17,20 @@ module.exports = function() {
     var identityId = req.headers['x-user-id'];
 
     if (!identityId) {
-
       log.error('Missing authorization header');
-      return next(new errors.UnauthorizedError('Missing authorization header'));
+      //return next(new errors.UnauthorizedError('Missing authorization header'));
+      err = new errors.UnauthorizedError('Missing authorization header');
+      res.status(err.statusCode).json(err.body);
+      return next(err);
     }
 
     if (!ObjectId.isValid(identityId)) {
 
       log.error('Invalid Authorization header format');
-      return next(new errors.InvalidHeaderError('Invalid Authorization header format'));
+      err = new errors.InvalidHeaderError('Invalid Authorization header format');
+      //return next(new errors.InvalidHeaderError('Invalid Authorization header format'));
+      res.status(err.statusCode).json(err.body);
+      return next(err);
     }
 
     identities.get(identityId, function(err, identity) {
@@ -35,7 +42,11 @@ module.exports = function() {
       if (!identity) {
 
         log.error('Identity not found');
-        return next(new errors.UnauthorizedError('Identity not found'));
+        err = new errors.UnauthorizedError('Identity not found');
+        res.status(err.statusCode).json(err.body);
+        res.end();
+        return next(err);
+        //return next(new errors.UnauthorizedError('Identity not found'));
       } else {
 
         req.identity = identity;

--- a/lib/middleware/validate_identity.js
+++ b/lib/middleware/validate_identity.js
@@ -1,13 +1,10 @@
 var errors = require('../util/errors');
 var ObjectId = require('mongoose').Types.ObjectId;
 var identities = require('../platforms/identity');
-var log = require('../util/logger');
 
 module.exports = function() {
 
   return function(req, res, next) {
-
-    var err;
 
     if (req.isPublic) {
       return next();
@@ -17,20 +14,11 @@ module.exports = function() {
     var identityId = req.headers['x-user-id'];
 
     if (!identityId) {
-      log.error('Missing authorization header');
-      //return next(new errors.UnauthorizedError('Missing authorization header'));
-      err = new errors.UnauthorizedError('Missing authorization header');
-      res.status(err.statusCode).json(err.body);
-      return next(err);
+      return next(new errors.UnauthorizedError('Missing authorization header'));
     }
 
     if (!ObjectId.isValid(identityId)) {
-
-      log.error('Invalid Authorization header format');
-      err = new errors.InvalidHeaderError('Invalid Authorization header format');
-      //return next(new errors.InvalidHeaderError('Invalid Authorization header format'));
-      res.status(err.statusCode).json(err.body);
-      return next(err);
+      return next(new errors.InvalidHeaderError('Invalid Authorization header format'));
     }
 
     identities.get(identityId, function(err, identity) {
@@ -40,13 +28,7 @@ module.exports = function() {
       }
 
       if (!identity) {
-
-        log.error('Identity not found');
-        err = new errors.UnauthorizedError('Identity not found');
-        res.status(err.statusCode).json(err.body);
-        res.end();
-        return next(err);
-        //return next(new errors.UnauthorizedError('Identity not found'));
+        return next(new errors.UnauthorizedError('Identity not found'));
       } else {
 
         req.identity = identity;

--- a/lib/platforms/channel.js
+++ b/lib/platforms/channel.js
@@ -1,5 +1,4 @@
 var Channel = require('../models/channel');
-var errors = require('../util/errors');
 var _ = require('lodash');
 var async = require('async');
 
@@ -23,13 +22,13 @@ function retrieveChannelDataForIdentity(identity, callback) {
   identities.get(identity, function(err, foundIdentity) {
 
     if (err || !foundIdentity) {
-      return callback(new errors.BadRequestError('Could not find Identity object'));
+      return callback(new Error('Could not find Identity object'));
     }
 
     Channel.find().where('name').in(foundIdentity.channels).exec(function(err, foundChannels) {
 
       if (err) {
-        return callback(new errors.BadRequestError('Could not fetch the channels associated to the provided Identity object'));
+        return callback(err);
       }
 
       var channelData = [];
@@ -51,10 +50,10 @@ function createChannel(channelData, callback) {
   Channel.findOne({name: channelData.name}, function(err, results) {
 
     if (err) {
-      return callback(new errors.InternalError('Channel creation process failed'));
+      return callback(err);
     }
     if (results && !_.isEmpty(results)) {
-      return callback(new errors.ConflictError('There already exists a channel with the provided name'));
+      return callback(new Error('There already exists a channel with the provided name'));
     }
 
     var formattedChannel = preProcessChannel(null, channelData);
@@ -64,7 +63,7 @@ function createChannel(channelData, callback) {
     channel.save(function(err, savedChannel) {
 
       if (err) {
-        return callback(new errors.InternalError('Could not save newly created Channel object to database'));
+        return callback(err);
       }
 
       return callback(null, savedChannel);
@@ -91,17 +90,17 @@ function preProcessChannel(channelToProcess, changes) {
 function deleteChannel(channelId, callback) {
 
   if (!channelId) {
-    return callback(new errors.BadRequestError('Missing channel id parameter'));
+    return callback(new Error('Missing channel id parameter'));
   }
 
   Channel.findOneAndRemove({'_id': channelId}, function(err, deletedChannel) {
 
     if (err) {
-      return callback(new errors.InternalError('Could not fetch Channel object to delete'));
+      return callback(err);
     }
 
     if (!deletedChannel) {
-      return callback(new errors.BadRequestError('Requested channel not found in database'));
+      return callback(new Error('Requested channel not found in database'));
     }
 
     var relatedIdentities = deletedChannel.identityRef;
@@ -113,7 +112,7 @@ function deleteChannel(channelId, callback) {
     identities.removeValuesFromField(deletedChannel.identityRef, 'channels', deletedChannel.name, function(err) {
 
       if (err) {
-        return callback(new errors.InternalError('Could not delete the provided Channel object'));
+        return callback(err);
       }
 
       return callback();
@@ -129,11 +128,11 @@ function updateChannel(channelId, changes, callback) {
       getChannel(channelId, function(err, foundChannel) {
 
         if (err) {
-          return done(new errors.InternalError('Could not fetch Channel object to edit'));
+          return done(err);
         }
 
         if (!foundChannel) {
-          return done(new errors.BadRequestError('Requested Channel object not found in database'));
+          return done(new Error('Requested Channel object not found in database'));
         }
 
         oldChannel = _.clone(foundChannel.toObject());
@@ -143,7 +142,7 @@ function updateChannel(channelId, changes, callback) {
         foundChannel.save(foundChannel, function(err, updatedChannel) {
 
           if (err) {
-            return done(new errors.InternalError('Could not update requested Channel object'));
+            return done(err);
           }
 
           return done(null, oldChannel, updatedChannel);
@@ -173,17 +172,17 @@ function updateChannel(channelId, changes, callback) {
 function retrieveIdentityListForChannel(channelId, callback) {
 
   if (!channelId) {
-    return callback(new errors.BadRequestError('Missing channel id parameter'));
+    return callback(new Error('Missing channel id parameter'));
   }
 
   getChannel(channelId, function(err, foundChannel) {
 
     if (err) {
-      return callback(new errors.InternalError('Could not fetch requested Channel object'));
+      return callback(err);
     }
 
     if (!foundChannel) {
-      return callback(new errors.BadRequestError('Requested Channel object not found in database'));
+      return callback(new Error('Requested Channel object not found in database'));
     }
 
     if (_.isEmpty(foundChannel.identityRef)) {
@@ -193,7 +192,7 @@ function retrieveIdentityListForChannel(channelId, callback) {
     identities.findIdentitiesByFieldValue('_id', foundChannel.identityRef, function(err, foundIdentities) {
 
       if (err) {
-        return callback(new errors.InternalError('Could not fetch Identities for the provided Channel object'));
+        return callback(err);
       }
 
       var identityList = [];
@@ -214,11 +213,11 @@ function deleteIdentityFromChannel(channelId, identityId, callback) {
       getChannel(channelId, function(err, foundChannel) {
 
         if (err) {
-          return done(new errors.BadRequestError('Could not fetch requested Channel object'));
+          return done(err);
         }
 
         if (_.isEmpty(foundChannel)) {
-          return done(new errors.BadRequestError('Requested Channel object not found in database'));
+          return done(new Error('Requested Channel object not found in database'));
         }
 
         return done(null, foundChannel);
@@ -229,11 +228,11 @@ function deleteIdentityFromChannel(channelId, identityId, callback) {
       identities.get(identityId, function(err, foundIdentity) {
 
         if (err) {
-          return done(new errors.BadRequestError('Could not fetch requested Identity object'));
+          return done(err);
         }
 
         if (_.isEmpty(foundIdentity)) {
-          return done(new errors.BadRequestError('Requested Identity object not found in database'));
+          return done(new Error('Requested Identity object not found in database'));
         }
 
         return done(null, channel, foundIdentity);
@@ -250,7 +249,7 @@ function deleteIdentityFromChannel(channelId, identityId, callback) {
       });
 
       if (!identityHasChannel || !channelHasIdentity) {
-        return done(new errors.ConflictError('No relationship exist between the provided Channel and Identity objects'));
+        return done(new Error('No relationship exist between the provided Channel and Identity objects'));
       }
 
       return done(null, channel, identity);
@@ -284,7 +283,7 @@ function removeValuesFromField(channelList, field, valuesToRemove, callback) {
   Channel.update(queryOptions, { $pull: pullOptions}, {multi: true}, function(err, result) {
 
     if (err) {
-      return callback(new errors.InternalError('Could not delete data from Channel object'));
+      return callback(err);
     }
 
     return callback(null, result);

--- a/lib/platforms/email.js
+++ b/lib/platforms/email.js
@@ -17,7 +17,6 @@ function sendEmailNotification(identities, body, callback) {
   transport.send(emails, body.content, function (err, response, body) {
 
     if (err) {
-      log.error('Error sending request to send emails', err);
       return callback(err);
     }
 

--- a/lib/platforms/identity.js
+++ b/lib/platforms/identity.js
@@ -55,8 +55,6 @@ function updateIdentityData(identity, changes, callback) {
   checkForIdentityExistence(identity, function(err, result) {
 
     if (err) {
-
-      log.error('Error checking the id existence', err);
       return callback(err);
     }
 
@@ -68,8 +66,6 @@ function updateIdentityData(identity, changes, callback) {
         identity.save(function(err){
 
           if (err) {
-
-            log.error('Error saving identity', err);
             return done(err);
           }
 
@@ -149,8 +145,6 @@ function createIdentity(identityObj, callback) {
       identity.save(function(err, savedIdentity) {
 
         if (err) {
-
-          log.error('Error saving the identity', err);
           return done(err);
         }
 
@@ -206,7 +200,7 @@ function checkForDuplicates(identity, field, callback) {
 function checkForIdentityExistence(identityObj, callback) {
 
   if (!identityObj) {
-    return callback(true);
+    return callback(new Error('No identity object provided'));
   }
 
   var mustCheck = {};
@@ -254,7 +248,7 @@ function checkForIdentityExistence(identityObj, callback) {
     });
 
     if (err || !isValid) {
-      return callback(true);
+      return callback(new Error('Some of the provided devices are not valid'));
     }
 
     return callback(null, identityObj);
@@ -276,7 +270,7 @@ function removeValuesFromField(identityList, field, valuesToRemove, callback) {
   Identity.update(queryOptions, { $pull: pullOptions}, {multi: true}, function(err, result) {
 
     if (err) {
-      return callback(true);
+      return callback(err);
     }
 
     return callback(null, result);

--- a/lib/platforms/orchestrator.js
+++ b/lib/platforms/orchestrator.js
@@ -84,7 +84,6 @@ function batchNotifications(requestBody, platformModule, queryOptions, callback)
   ], function(err) {
 
     if (err) {
-      log.error('Sending notifications failed', err);
       return callback(err);
     }
 
@@ -142,7 +141,6 @@ function sendBatches(requestBody, queryOptions, totalIdentities, platformModule,
         log.info('batch %d found identities %s', page, foundIdentities);
 
         if (err) {
-          log.error('Fatal error while searching for identities to send notifications');
           return nextBatch(err);
         }
 
@@ -157,7 +155,6 @@ function sendBatches(requestBody, queryOptions, totalIdentities, platformModule,
           log.info('Sending notifications');
 
           if (err) {
-            log.error('Fatal error while sending notifications', err);
             return nextBatch(err);
           }
 

--- a/lib/platforms/push.js
+++ b/lib/platforms/push.js
@@ -47,8 +47,6 @@ function deleteApnDevices(devices, callback){
     }, function(err){
 
         if (err) {
-
-            log.error('Error deleting apn devices', err);
             return callback(err);
         }
 

--- a/lib/platforms/sms.js
+++ b/lib/platforms/sms.js
@@ -39,7 +39,6 @@ function sendSmsNotification(identities, body, callback) {
   }, function (err) {
 
     if (err) {
-      log.error('Error sending sms notifications', err);
       return callback(err);
     }
 

--- a/lib/routes/channel.js
+++ b/lib/routes/channel.js
@@ -20,10 +20,6 @@ routes.getChannel = function(req, res, next) {
 
   var identity = req.identity;
 
-  if (!identity) {
-    return next(new errors.BadRequestError('Unknown provided identity'));
-  }
-
   channels.retrieveChannelDataForIdentity(identity, function(err, channelData) {
 
     if (err) {

--- a/lib/routes/identity.js
+++ b/lib/routes/identity.js
@@ -16,7 +16,7 @@ routes.getIdentity = function(req, res, next) {
   var identity = req.identity;
 
   if (!identity) {
-    return next(new errors.BadRequestError('Unknown identity'));
+    return next(new errors.BadRequestError('No identity provided'));
   }
 
   var formattedIdentity = identities.formatIdentity(identity);
@@ -27,7 +27,6 @@ routes.getIdentity = function(req, res, next) {
 routes.createIdentity = function(req, res, next) {
 
   identities.createIdentity(req.body, function(err, createdIdentityId) {
-
     if (err) {
       return next(new errors.ConflictError('Could not create requested Identity object'));
     }

--- a/lib/routes/identity.js
+++ b/lib/routes/identity.js
@@ -27,8 +27,9 @@ routes.getIdentity = function(req, res, next) {
 routes.createIdentity = function(req, res, next) {
 
   identities.createIdentity(req.body, function(err, createdIdentityId) {
+
     if (err) {
-      return next(new errors.ConflictError('Could not create requested Identity object'));
+      return next(err);
     }
 
     res.status(201).send({id: createdIdentityId});
@@ -46,7 +47,7 @@ routes.updateIdentity = function(req, res, next) {
   identities.updateIdentityData(identityObj, req.body, function(err) {
 
     if (err) {
-      return next(new errors.BadRequestError('Could not update identity data'));
+      return next(err);
     }
 
     res.sendStatus(204);
@@ -65,7 +66,7 @@ routes.getIdentityById = function(req, res, next) {
   identities.get(identityId, function(err, foundIdentity) {
 
     if (err) {
-      return next(new errors.NotFoundError('Could not find identity for provided identifier'));
+      return next(err);
     }
 
     if (!foundIdentity) {

--- a/lib/routes/push.js
+++ b/lib/routes/push.js
@@ -15,7 +15,7 @@ routes.sendPushNotification = function(req, res, next) {
     orchestrator.sendPushNotifications(req.body, pushPlatform, function(err /*, response */) {
 
         if (err) {
-            return next(new errors.InternalError('Could not send PUSH Notification to destination'));
+            return next(err);
         }
 
         res.sendStatus(204);

--- a/lib/routes/sms.js
+++ b/lib/routes/sms.js
@@ -14,7 +14,7 @@ routes.sendSmsNotification = function(req, res, next) {
     orchestrator.sendNotification(req.body, smsPlatform, function(err/*, response */) {
 
         if (err) {
-            return next(new errors.InternalError('Could not send SMS to destination'));
+            return next(err);
         }
 
         res.sendStatus(204);

--- a/lib/service.js
+++ b/lib/service.js
@@ -56,7 +56,7 @@ function logErrors(err, req, res, next) {
   next(err);
 }
 
-function errorHandler(err, req, res) {
+function errorHandler(err, req, res, next) {
 
   if (err instanceof errors.HttpError) {
     res.status(err.statusCode).json(err.body);
@@ -64,6 +64,7 @@ function errorHandler(err, req, res) {
   }
 
   res.status(500).json({code: 'InternalError', message: err.message || 'Fatal error'});
+  return next();
 }
 
 module.exports = server;

--- a/package.json
+++ b/package.json
@@ -67,6 +67,8 @@
     "lcov-result-merger": "^1.0.2",
     "mocha": "^2.2.5",
     "mocha-lcov-reporter": "0.0.2",
+    "mock-express-request": "^0.1.1",
+    "mock-express-response": "^0.1.1",
     "nock": "^2.9.1",
     "pre-commit": "^1.0.10",
     "proxyquire": "^1.7.0",

--- a/test/middlewares/check_identity.js
+++ b/test/middlewares/check_identity.js
@@ -1,6 +1,7 @@
 require('./../global_conf');
 
 var expect = require('chai').expect;
+var mockRequestResponse = require('mock-express-response');
 
 var checkIdentity = require('./../../lib/middleware/validate_identity');
 
@@ -22,7 +23,7 @@ describe('Identity middleware', function() {
   it('returns an UnauthorizedError for no x-user-id header', function(done) {
 
     request.headers = {};
-    var res = {};
+    var res = new mockRequestResponse();
 
     var next = function(error) {
       expect(error.statusCode).to.equal(401);
@@ -37,7 +38,7 @@ describe('Identity middleware', function() {
   it('returns an InvalidHeader error for a badly formatted x-user-id header', function(done) {
 
     request.headers['x-user-id'] = 'asdf1111ccccblah';
-    var res = {};
+    var res = new mockRequestResponse();
 
     var next = function(error) {
       expect(error.statusCode).to.equal(400);
@@ -52,7 +53,7 @@ describe('Identity middleware', function() {
   it('returns an UnauthorizedError error for a non-existing Identity object', function(done) {
 
     request.headers['x-user-id'] = '01f0000123400000003f0043';
-    var res = {};
+    var res = new mockRequestResponse();
 
     var next = function(error) {
       expect(error.statusCode).to.equal(401);
@@ -67,7 +68,7 @@ describe('Identity middleware', function() {
   it('passes validations for a well-formatted x-user-id header', function(done) {
 
     request.headers['x-user-id'] = '01f0000000000000003f0001';
-    var res = {};
+    var res = new mockRequestResponse();
 
     var next = function(error) {
       var requestIdentityId = request.identity._id;


### PR DESCRIPTION
Restify-to-Express conversion finished with Mocha and Cucumber tests updated accordingly.
HttpErrors are sent from the Express error handler. 

The platform modules yield standard Error objects when an error occurs, either due to an exception caused by MongoDB or any other third-party module, or due to an error condition specified on our own.