### PR TITLE
Improve Dockerfile layer caching and add ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
 FROM nodesource/node:4.1
 
+RUN mkdir /app
+COPY package.json /tmp/package.json
+RUN cd /tmp && npm install
+RUN cp -a /tmp/node_modules /app
+
 WORKDIR /app
-ADD package.json /app/package.json
-ADD . /app
-RUN npm install
+COPY . /app
 
-
-CMD ["npm", "start"]
+ENTRYPOINT ["npm"]
+CMD ["start"]


### PR DESCRIPTION
Improve caching of layers running `npm install` only if `package.json` changes, instead of any change in the app code.

Add `ENTRYPOINT` to support setting npm commands just overriding the default `CMD` (e.g. for running tests with the container when `CMD` is `test`).