### PR TITLE
Add sleep after docker-compose -d

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -22,7 +22,7 @@ test:
     - npm run coverage-4
     - npm run coverage-5
     - npm run coverage-6
-    - cd test/dockerized-testing-environment && docker-compose up -d && docker-compose run resonator run dockertest
+    - cd test/dockerized-testing-environment && docker-compose up -d && sleep 5 && docker-compose run resonator run dockertest
 deployment:
   npm_dockerhub:
     branch: master


### PR DESCRIPTION
Improve the tests, waiting 5 seconds for `docker-compose up -d` to finish starting the 2 containers. I haven't found a better alternative using the docker tools.