### PR TITLE
Marked 'heartbeat' endpoint as public: no auth headers required to ac…

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -24,6 +24,9 @@
         "endpoint": "/api/identity"
       },
       {
+        "endpoint": "/heartbeat"
+      },
+      {
         "endpoint": "/api/notification.*"
       },
       {

--- a/cucumber/features/heartbeat.feature
+++ b/cucumber/features/heartbeat.feature
@@ -1,12 +1,5 @@
 Feature: Notifications component sends a 204 to confirm it is running
 
-  Scenario Outline: get the status of the notifications server
-    Given an authenticated identity in the app with <identity_id>
+  Scenario: get the status of the notifications server
     When a user makes a GET to /heartbeat
     Then the backend responds with 204
-
-  Examples:
-    | identity_id               |
-    | 01f0000000000000003f0001  |
-    | 01f0000000000000003f0002  |
-    | 01f0000000000000003f0003  |

--- a/cucumber/features/step_definitions/request_steps.js
+++ b/cucumber/features/step_definitions/request_steps.js
@@ -9,9 +9,9 @@ module.exports = function() {
   this.When(/^a user makes a GET to (.*)$/, function(endpoint, callback) {
     this.register('url', endpoint);
 
-    const request = this.buildRequest('GET', endpoint, {
-      'x-user-id': this.get('identity')
-    });
+    const headers = this.get('identity') ? { 'x-user-id': this.get('identity')} : {};
+
+    const request = this.buildRequest('GET', endpoint, headers);
 
     this.register('request', request);
     return callback();

--- a/test/middlewares/check_identity.js
+++ b/test/middlewares/check_identity.js
@@ -9,10 +9,10 @@ const loadFixtures = require('./../../scripts/load_fixtures');
 
 describe('Identity middleware', function() {
 
-  const hearbeatUrl = '/heartbeat';
+  const fetchIdentityUrl = '/api/identity';
 
   let request = {
-    url: hearbeatUrl,
+    url: fetchIdentityUrl,
     method: 'GET',
     headers: {}
   };


### PR DESCRIPTION
…cess it. Updated corresponding Cucumber tests. Changed Mocha test to target endpoint different from 'heartbeat'.